### PR TITLE
Fix translation placeholder typo

### DIFF
--- a/src/app/pages/translation/translation.component.html
+++ b/src/app/pages/translation/translation.component.html
@@ -21,7 +21,7 @@
         <label for="question" class="block mb-2 text-sm font-medium text-left text-gray-700">Gimme the
           {{isTextTranslation ? 'text' : 'word'}} to
           translate?</label>
-        <input id="question" type="text" placeholder="e.g., {{isTextTranslation ? 'De mooite ward':'Geven'}}"
+        <input id="question" type="text" placeholder="e.g., {{isTextTranslation ? 'De moeite waard':'Geven'}}"
           [(ngModel)]="prompt" [ngClass]="{ 'invalid': questionRef.touched && questionRef.invalid }"
           #questionRef="ngModel"
           class="w-full px-4 py-3 rounded-md border bg-gray-50 placeholder-gray-400 text-indigo-950 focus:outline-none focus:ring-2 focus:ring-indigo-500"


### PR DESCRIPTION
## Summary
- correct placeholder text spelling in translation component

## Testing
- `npm test --silent` *(fails: No inputs were found in tsconfig.spec.json)*

------
https://chatgpt.com/codex/tasks/task_e_683f3c92aee48324baf3f5fb49a7fc5a